### PR TITLE
resolve #1 - add templates for AsciiDoc processing instructions

### DIFF
--- a/pressgang-jdocbook-style/src/main/css/css/documentation.css
+++ b/pressgang-jdocbook-style/src/main/css/css/documentation.css
@@ -549,3 +549,14 @@ ul li p:last-child {
     margin-bottom:0em;
     padding-bottom:0em;
 }
+
+.page-break {
+    display: none;
+}
+
+@media print {
+    .page-break {
+        display: block;
+        page-break-before: always;
+    }
+}

--- a/pressgang-xslt-ns/src/main/resources/xslt/org/jboss/pressgang/common-base.xsl
+++ b/pressgang-xslt-ns/src/main/resources/xslt/org/jboss/pressgang/common-base.xsl
@@ -12,10 +12,24 @@
     -->
     <xsl:param name="confidential" select="0"/>
 
+    <xsl:param name="asciidoc.mode">0</xsl:param>
+
     <!--
         TOC
     -->
-    <xsl:param name="section.autolabel" select="1"/>
+    <xsl:param name="section.autolabel">
+        <xsl:choose>
+            <xsl:when test="$asciidoc.mode = 0">1</xsl:when>
+            <xsl:when test="/processing-instruction('asciidoc-numbered')">1</xsl:when>
+            <xsl:otherwise>0</xsl:otherwise>
+        </xsl:choose>
+    </xsl:param>
+    <xsl:param name="section.autolabel.max.depth">
+        <xsl:choose>
+            <xsl:when test="$asciidoc.mode = 0">8</xsl:when>
+            <xsl:otherwise>2</xsl:otherwise>
+        </xsl:choose>
+    </xsl:param>
     <xsl:param name="section.label.includes.component.label" select="1"/>
 
     <!--

--- a/pressgang-xslt-ns/src/main/resources/xslt/org/jboss/pressgang/common-xhtml.xsl
+++ b/pressgang-xslt-ns/src/main/resources/xslt/org/jboss/pressgang/common-xhtml.xsl
@@ -45,19 +45,46 @@
 
     <!-- TOC: remove list of figures, list of tables, ... Only keep Table of Contents -->
     <xsl:param name="generate.toc">
-        set toc
-        book toc
-        article toc
-        chapter toc
-        qandadiv toc
-        qandaset toc
-        sect1 nop
-        sect2 nop
-        sect3 nop
-        sect4 nop
-        sect5 nop
-        section toc
-        part toc
+        <xsl:choose>
+            <xsl:when test="$asciidoc.mode = 0">
+set toc
+book toc
+article toc
+chapter toc
+qandadiv toc
+qandaset toc
+sect1 nop
+sect2 nop
+sect3 nop
+sect4 nop
+sect5 nop
+section toc
+part toc
+            </xsl:when>
+            <xsl:when test="/processing-instruction('asciidoc-toc')">
+article toc,title
+book    toc,title,figure,table,example,equation
+                <xsl:if test="$generate.section.toc.level != 0">
+chapter   toc,title
+part      toc,title
+preface   toc,title
+qandadiv  toc
+qandaset  toc
+reference toc,title
+sect1     toc
+sect2     toc
+sect3     toc
+sect4     toc
+sect5     toc
+section   toc
+set       toc,title
+                </xsl:if>
+            </xsl:when>
+            <xsl:otherwise>
+article nop
+book    nop
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:param>
 
     <!-- TEMPLATES -->
@@ -178,6 +205,21 @@
             </xsl:choose>
         </pre>
 
+    </xsl:template>
+
+    <!-- Forced line break -->
+    <xsl:template match="processing-instruction('asciidoc-br')">
+        <br/>
+    </xsl:template>
+
+    <!-- Forced page break -->
+    <xsl:template match="processing-instruction('asciidoc-pagebreak')">
+       <div class="page-break"/>
+    </xsl:template>
+
+    <!-- Horizontal ruler -->
+    <xsl:template match="processing-instruction('asciidoc-hr')">
+        <hr/>
     </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
AsciiDoc inserts processing instructions into the generated DocBook. This patch adds XSL templates that handle those processing instructions consistence with the stylesheets in the AsciiDoc distribution.
- templates for AsciiDoc pis (line break, page break, rule)
- add asciidoc.mode to tune defaults when using AsciiDoc output
- set defaults for toc and numbered based on AsciiDoc pis when asciidoc.mode = 1
- fix inlinemediaimage to behave as an inline element
