### PR TITLE
PRESSGANG-94 Upgrade Docbook XSL to 1.79.1 and use (X)HTML5 output

### DIFF
--- a/pressgang-jdocbook-style/src/main/css/css/documentation.css
+++ b/pressgang-jdocbook-style/src/main/css/css/documentation.css
@@ -517,7 +517,7 @@ li p:first-child {
     padding:0em !important;
 }
 
-div.chapter, div.section {padding-top:2em;}
+section.chapter, section.section {padding-top:2em;}
 
 .revhistory {}
 

--- a/pressgang-jdocbook-style/src/main/css/css/jbossorg.css
+++ b/pressgang-jdocbook-style/src/main/css/css/jbossorg.css
@@ -38,7 +38,7 @@ h1, h2, h3, h4, h5, h6 {
     background-color:transparent;
 }
 
-h1 {
+div.book > div.titlepage h1 {
     background-image:url(../images/community/title_hdr.png);
     background-repeat:no-repeat;
     border-top:1px dotted #CCCCCC;
@@ -48,21 +48,21 @@ h1 {
     padding:1.5em;
 }
 
-h2 {font-size:1.6em;}
+h1 {font-size:1.6em;}
 
-h3 {
+h2 {
     font-size:1.3em;
     padding-top:0em;
     padding-bottom:0em;
 }
 
-h4 {
+h3 {
     font-size:1.1em;
     padding-top:0em;
     padding-bottom:0em;
 }
 
-h5.formalpara {
+h4.formalpara {
     font-size:1em;
     margin-top:2em;
     margin-bottom:.8em;

--- a/pressgang-tools-example/pom.xml
+++ b/pressgang-tools-example/pom.xml
@@ -23,7 +23,7 @@
         <plugin>
           <groupId>org.jboss.maven.plugins</groupId>
           <artifactId>maven-jdocbook-plugin</artifactId>
-          <version>2.3.9</version>
+          <version>2.3.10</version>
           <extensions>true</extensions>
 
           <dependencies>
@@ -98,7 +98,7 @@
               <!-- Entry needed to enable jdocbook unzipping -->
               <groupId>org.jboss.maven.plugins</groupId>
               <artifactId>maven-jdocbook-plugin</artifactId>
-              <version>2.3.9</version>
+              <version>2.3.10</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pressgang-xslt-ns/pom.xml
+++ b/pressgang-xslt-ns/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>net.sf.docbook</groupId>
             <artifactId>docbook-xsl</artifactId>
-            <version>1.76.1</version>
+            <version>1.79.1</version>
             <classifier>ns-resources</classifier>
             <type>zip</type>
         </dependency>

--- a/pressgang-xslt-ns/src/main/resources/xslt/org/jboss/pressgang/common-base.xsl
+++ b/pressgang-xslt-ns/src/main/resources/xslt/org/jboss/pressgang/common-base.xsl
@@ -54,4 +54,15 @@
         <xsl:text>images/community/docbook/</xsl:text>
     </xsl:param>
 
+    <!--
+        Callout support
+    -->
+    <xsl:param name="callout.graphics" select="1"/>
+    <xsl:param name="callout.graphics.path">
+        <xsl:if test="$img.src.path != ''">
+            <xsl:value-of select="concat($img.src.path, 'callouts/')"/>
+        </xsl:if>
+        <xsl:text>images/community/docbook/callouts/</xsl:text>
+    </xsl:param>
+
 </xsl:stylesheet>

--- a/pressgang-xslt-ns/src/main/resources/xslt/org/jboss/pressgang/common-xhtml.xsl
+++ b/pressgang-xslt-ns/src/main/resources/xslt/org/jboss/pressgang/common-xhtml.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:d="http://docbook.org/ns/docbook"
                 xmlns="http://www.w3.org/1999/xhtml"
-                exclude-result-prefixes="d"
+                exclude-result-prefixes="#default d"
                 version="1.0">
 
     <!-- IMPORTS && INCLUDES -->
@@ -23,8 +23,9 @@
     <xsl:param name="chunk.section.depth" select="0"/>
     <xsl:param name="chunk.first.sections" select="1"/>
     <xsl:param name="chunk.toc" select="''"/>
-    <xsl:param name="chunker.output.doctype-public" select="'-//W3C//DTD XHTML 1.0 Strict//EN'"/>
-    <xsl:param name="chunker.output.doctype-system" select="'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd'"/>
+    <xsl:param name="chunker.output.omit-xml-declaration" select="'yes'" />
+    <xsl:param name="chunker.output.doctype-public" select="''"/>
+    <xsl:param name="chunker.output.doctype-system" select="''"/>
     <xsl:param name="chunker.output.encoding" select="'UTF-8'"/>
 
     <xsl:param name="graphicsize.extension">0</xsl:param>
@@ -93,10 +94,9 @@ book    nop
 
     <!-- TEMPLATES -->
     <xsl:output method="xml"
+                omit-xml-declaration="yes"
                 encoding="UTF-8"
-                standalone="no"
-                doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"
-                doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"/>
+                standalone="no"/>
 
     <!--
         Comes from xhtml/docbook.xsl
@@ -112,11 +112,11 @@ book    nop
         Used to add google analytics script.
     -->
     <xsl:template name="user.footer.content">
-        <script type="text/javascript" src="highlight.js/highlight.pack.js">
+        <script type="text/javascript" src="highlight.js/highlight.pack.js" xmlns="http://www.w3.org/1999/xhtml">
             <!-- Workaround to force outputting "</script>". The space is required. -->
             <xsl:text> </xsl:text>
         </script>
-        <script type="text/javascript">
+        <script type="text/javascript" xmlns="http://www.w3.org/1999/xhtml">
             <xsl:text>hljs.initHighlightingOnLoad();</xsl:text>
         </script>
         <xsl:if test="$html.googleAnalyticsId != ''">
@@ -220,17 +220,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&amp;l='+l:'';j.async=true;j.src=
 
     <!-- Forced line break -->
     <xsl:template match="processing-instruction('asciidoc-br')">
-        <br/>
+        <br xmlns="http://www.w3.org/1999/xhtml"/>
     </xsl:template>
 
     <!-- Forced page break -->
     <xsl:template match="processing-instruction('asciidoc-pagebreak')">
-       <div class="page-break"/>
+       <div class="page-break" xmlns="http://www.w3.org/1999/xhtml"/>
     </xsl:template>
 
     <!-- Horizontal ruler -->
     <xsl:template match="processing-instruction('asciidoc-hr')">
-        <hr/>
+        <hr xmlns="http://www.w3.org/1999/xhtml"/>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/pressgang-xslt-ns/src/main/resources/xslt/org/jboss/pressgang/pdf.xsl
+++ b/pressgang-xslt-ns/src/main/resources/xslt/org/jboss/pressgang/pdf.xsl
@@ -7,7 +7,7 @@
                 version="1.0">
 
     <!-- IMPORTS -->
-    <xsl:import href="http://docbook.sourceforge.net/release/xsl/1.76.1/fo/docbook.xsl"/>
+    <xsl:import href="http://docbook.sourceforge.net/release/xsl/1.79.1/fo/docbook.xsl"/>
 
     <!-- INCLUDES -->
     <xsl:include href="common-base.xsl"/>

--- a/pressgang-xslt-ns/src/main/resources/xslt/org/jboss/pressgang/xhtml-single.xsl
+++ b/pressgang-xslt-ns/src/main/resources/xslt/org/jboss/pressgang/xhtml-single.xsl
@@ -2,11 +2,11 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:d="http://docbook.org/ns/docbook"
                 xmlns="http://www.w3.org/1999/xhtml"
-                exclude-result-prefixes="d"
+                exclude-result-prefixes="#default d"
                 version="1.0">
 
     <!-- IMPORTS && INCLUDES -->
-    <xsl:import href="http://docbook.sourceforge.net/release/xsl/1.76.1/xhtml/docbook.xsl"/>
+    <xsl:import href="http://docbook.sourceforge.net/release/xsl/1.79.1/xhtml5/docbook.xsl"/>
     <xsl:include href="common-xhtml.xsl"/>
 
     <!--

--- a/pressgang-xslt-ns/src/main/resources/xslt/org/jboss/pressgang/xhtml.xsl
+++ b/pressgang-xslt-ns/src/main/resources/xslt/org/jboss/pressgang/xhtml.xsl
@@ -2,11 +2,11 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:d="http://docbook.org/ns/docbook"
                 xmlns="http://www.w3.org/1999/xhtml"
-                exclude-result-prefixes="d"
+                exclude-result-prefixes="#default d"
                 version="1.0">
 
     <!-- IMPORTS && INCLUDES -->
-    <xsl:import href="http://docbook.sourceforge.net/release/xsl/1.76.1/xhtml/chunk.xsl"/>
+    <xsl:import href="http://docbook.sourceforge.net/release/xsl/1.79.1/xhtml5/chunk.xsl"/>
     <xsl:include href="common-xhtml.xsl"/>
 
 


### PR DESCRIPTION
- https://issues.jboss.org/browse/PRESSGANG-94
- https://issues.jboss.org/browse/PRESSGANG-95

PR to be updated once version 2.3.10 of maven-jdocbook-plugin is released.
